### PR TITLE
Chore/coverage

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#e05d44" d="M63 0h36v20H63z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">0%</text>
-        <text x="80" y="14">0%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">83%</text>
+        <text x="80" y="14">83%</text>
     </g>
 </svg>

--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -1,4 +1,4 @@
-name: CoFMPy formatting/linting
+name: pylint
 
 on:
   push:

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -34,7 +34,7 @@ jobs:
         run: coverage-badge -o .github/badges/coverage.svg
 
       - name: Commit coverage badge
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/chore/coverage'
         uses: EndBug/add-and-commit@v9
         with:
           add: '.github/badges/coverage.svg'

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -34,7 +34,9 @@ jobs:
         run: pytest --cov=cofmpy --cov-report=xml
 
       - name: Generate coverage badge
-        run: coverage-badge -f -o .github/badges/coverage.svg
+        run: | 
+          mkdir -p /tmp/badge
+          coverage-badge -f -o /tmp/badge/coverage.svg
 
       - name: Switch to `badges` branch and copy badge
         run: |
@@ -44,7 +46,7 @@ jobs:
           git fetch origin badges
           git checkout badges
 
-          cp .github/badges/coverage.svg .github/badges/coverage.svg
+          cp /tmp/badge/coverage.svg .github/badges/coverage.svg
 
       - name: Commit badge to `badges` branch
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -1,5 +1,8 @@
 name: coverage
 
+permissions:
+  contents: write # Required to commit the coverage badge
+
 on:
   push:
     branches: 

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches: 
       - main
-  pull_request:
-    branches: [main]
 
 jobs:
   coverage:

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -1,0 +1,40 @@
+name: Python tests coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]   
+
+      - name: Run tests and generate coverage report
+        run: pytest --cov=cofmpy --cov-report=xml
+
+      - name: Generate coverage badge
+        uses: tj-actions/coverage-badge-py@v2
+        with:
+          output: .github/badges/coverage.svg
+
+      - name: Commit coverage badge
+        if: github.ref == 'refs/heads/main'
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: '.github/badges/coverage.svg'
+          message: 'Update coverage badge'

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -24,15 +24,14 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]   
+          pip install .[dev] 
+          pip install coverage-badge  
 
       - name: Run tests and generate coverage report
         run: pytest --cov=cofmpy --cov-report=xml
 
       - name: Generate coverage badge
-        uses: tj-actions/coverage-badge-py@v2
-        with:
-          output: .github/badges/coverage.svg
+        run: coverage-badge -o .github/badges/coverage.svg
 
       - name: Commit coverage badge
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev] 
+          pip install -e .[dev]
           pip install coverage-badge  
 
       - name: Run tests and generate coverage report

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -36,10 +36,19 @@ jobs:
       - name: Generate coverage badge
         run: coverage-badge -f -o .github/badges/coverage.svg
 
+      - name: Switch to `badges` branch and copy badge
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          git fetch origin badges
+          git checkout badges
+
+          cp .github/badges/coverage.svg .github/badges/coverage.svg
+
       - name: Commit badge to `badges` branch
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Update coverage badge"
           branch: badges
-          create_branch: true
           file_pattern: .github/badges/coverage.svg

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -36,12 +36,10 @@ jobs:
       - name: Generate coverage badge
         run: coverage-badge -f -o .github/badges/coverage.svg
 
-      - name: Commit coverage badge
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/chore/coverage'
-        uses: EndBug/add-and-commit@v9
+      - name: Commit badge to `badges` branch
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          add: '.github/badges/coverage.svg'
-          message: 'Update coverage badge'
-          push: true
-          # Only commit if changes exist:
-          condition: true
+          commit_message: "Update coverage badge"
+          branch: badges
+          create_branch: true
+          file_pattern: .github/badges/coverage.svg

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -1,8 +1,10 @@
-name: Python tests coverage
+name: coverage
 
 on:
   push:
-    branches: [main]
+    branches: 
+      - main
+      - chore/coverage
   pull_request:
     branches: [main]
 

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: 
       - main
-      - chore/coverage
   pull_request:
     branches: [main]
 

--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -34,7 +34,7 @@ jobs:
         run: pytest --cov=cofmpy --cov-report=xml
 
       - name: Generate coverage badge
-        run: coverage-badge -o .github/badges/coverage.svg
+        run: coverage-badge -f -o .github/badges/coverage.svg
 
       - name: Commit coverage badge
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/chore/coverage'
@@ -42,3 +42,6 @@ jobs:
         with:
           add: '.github/badges/coverage.svg'
           message: 'Update coverage badge'
+          push: true
+          # Only commit if changes exist:
+          condition: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,4 @@
-name: CoFMPy pytests
+name: tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@
 </div>
 <br>
 
+<!-- Badge section -->
+<div align="center">
+    <a href="#">
+        <img src="https://img.shields.io/badge/python-3.9%2B-blue"></a>
+     <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/LICENSE">
+        <img alt="License BSD" src="https://img.shields.io/badge/License-BSD%202--Clause-blue.svg"></a>
+    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-linters.yml">
+        <img alt="Pylint" src="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-linters.yml/badge.svg"></a>
+    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests.yml">
+        <img alt="Tests" src="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests.yml/badge.svg"></a>
+    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests-coverage.yml">
+        <img alt="Coverage" src="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests-coverage.yml/coverage.svg"></a>
+   
+</div>
+<br>
+
 ## 👋 About CoFMPy
 
 CoFMPy is a Python library designed for co-simulating Functional Mock-up Units (FMUs).
@@ -61,7 +77,6 @@ entry point of CoFMPy and it manages all the other components:
 - the data stream handlers that control the input data required by the co-simulation
   system.
 - the data storages that allow to store or send the outputs of the simulation.
-- the GUI as the frontend of CoFMPy.
 
 ## 📜 JSON configuration file
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests.yml">
         <img alt="Tests" src="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests.yml/badge.svg"></a>
     <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests-coverage.yml">
-        <img alt="Coverage" src="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests-coverage.yml/coverage.svg"></a>
+        <img alt="Coverage" src="https://raw.githubusercontent.com/IRT-Saint-Exupery/CoFMPy/chore/coverage/.github/badges/coverage.svg""></a>
    
 </div>
 <br>

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
         <img src="https://img.shields.io/badge/python-3.9%2B-blue"></a>
      <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/LICENSE">
         <img alt="License BSD" src="https://img.shields.io/badge/License-BSD%202--Clause-blue.svg"></a>
-    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-linters.yml">
-        <img alt="Pylint" src="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-linters.yml/badge.svg"></a>
-    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests.yml">
-        <img alt="Tests" src="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests.yml/badge.svg"></a>
-    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests-coverage.yml">
-        <img alt="Coverage" src="https://github.com/IRT-Saint-Exupery/CoFMPy/blob/main/.github/workflows/python-tests-coverage.yml/coverage.svg"></a>
+    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-linters.yml">
+        <img alt="Pylint" src="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-linters.yml/badge.svg"></a>
+    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests.yml">
+        <img alt="Tests" src="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests.yml/badge.svg"></a>
+    <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests-coverage.yml">
+        <img alt="Coverage" src="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests-coverage.yml/coverage.svg"></a>
    
 </div>
 <br>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests.yml">
         <img alt="Tests" src="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests.yml/badge.svg"></a>
     <a href="https://github.com/IRT-Saint-Exupery/CoFMPy/actions/workflows/python-tests-coverage.yml">
-        <img alt="Coverage" src="https://raw.githubusercontent.com/IRT-Saint-Exupery/CoFMPy/chore/coverage/.github/badges/coverage.svg""></a>
+        <img alt="Coverage" src="https://raw.githubusercontent.com/IRT-Saint-Exupery/CoFMPy/badges/.github/badges/coverage.svg""></a>
    
 </div>
 <br>


### PR DESCRIPTION
This PR enhances the repository's visibility and CI feedback by:

- Adding multiple status badges (Python version, license, linting, tests, and test coverage).
- Enabling dynamic test coverage badge generation on each main push/PR through `python-tests-coverage.yml` workflow.
- Committing the coverage badge to a dedicated badges branch to avoid polluting main.
- Renaming GitHub Actions workflow files for better readability and consistency.


Notes: 

- The badge section is centered at the top of the README.
- The badges branch only contains .github/badges/coverage.svg and is automatically updated by the CI.