### PR TITLE
Fix coverage CI workflow: pull LFS files 

### DIFF
--- a/.github/workflows/python-tests-coverage.yml
+++ b/.github/workflows/python-tests-coverage.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: 
+    branches:
       - main
       - dev
   pull_request:
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -29,13 +31,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
-          pip install coverage-badge  
+          pip install coverage-badge
 
       - name: Run tests and generate coverage report
         run: pytest --cov=cofmpy --cov-report=xml
 
       - name: Generate coverage badge
-        run: | 
+        run: |
           mkdir -p /tmp/badge
           coverage-badge -f -o /tmp/badge/coverage.svg
 


### PR DESCRIPTION
The coverage CI workflow was left over when introducing LFS for FMU files. See "coverage" GitHub action [here](https://github.com/IRT-Saint-Exupery/CoFMPy/actions/runs/19467707177).
This commit adds the retrieval of large files when checking out the repo in the CI workflow:
```yaml
uses: actions/checkout@v4
with:
    lfs: true
```