### PR TITLE
Introduce BaseMaster

### DIFF
--- a/cofmupy/config_parser.py
+++ b/cofmupy/config_parser.py
@@ -185,7 +185,7 @@ class ConfigParser:
             fmu = fmu.asdict()
             fmu["path"] = self._find_corrected_relative_path(fmu["path"])
             fmus.append(fmu)
-        config["fmus"] = fmus
+        config["fmu_config_list"] = fmus
         config["connections"] = {}
         config["sequence_order"] = None
         config["cosim_method"] = self._config_object.cosim_method

--- a/cofmupy/config_parser.py
+++ b/cofmupy/config_parser.py
@@ -178,16 +178,18 @@ class ConfigParser:
             None. Builds self.master_config.
         """
 
+        config = {}
+
         fmus = []
         for fmu in self._config_object.fmus:
             fmu = fmu.asdict()
             fmu["path"] = self._find_corrected_relative_path(fmu["path"])
             fmus.append(fmu)
-        self.master_config["fmus"] = fmus
-        self.master_config["connections"] = {}
-        self.master_config["sequence_order"] = None
-        self.master_config["cosim_method"] = self._config_object.cosim_method
-        self.master_config["iterative"] = self._config_object.iterative
+        config["fmus"] = fmus
+        config["connections"] = {}
+        config["sequence_order"] = None
+        config["cosim_method"] = self._config_object.cosim_method
+        config["iterative"] = self._config_object.iterative
 
         for connection in self._config_object.connections:
             source = connection.source
@@ -195,17 +197,16 @@ class ConfigParser:
 
                 if source.type == target.type == FMU_TYPE:
                     # Initialize list of connections from source if not yet present
-                    if (source.id, source.variable) not in self.master_config[
-                        "connections"
-                    ]:
-                        self.master_config["connections"][
-                            (source.id, source.variable)
-                        ] = []
+                    if (source.id, source.variable) not in config["connections"]:
+                        config["connections"][(source.id, source.variable)] = []
 
                     # Append target connection to the source
-                    self.master_config["connections"][
-                        (source.id, source.variable)
-                    ].append((target.id, target.variable))
+                    config["connections"][(source.id, source.variable)].append(
+                        (target.id, target.variable)
+                    )
+
+        self.master_config["type"] = "default"
+        self.master_config["config"] = config
 
     def _build_handlers_config(self) -> None:
         """

--- a/cofmupy/coordinator.py
+++ b/cofmupy/coordinator.py
@@ -32,7 +32,7 @@ from .config_parser import ConfigParser
 from .data_storage.storage_handler import StorageHandler
 from .data_stream_handler import BaseDataStreamHandler
 from .graph_engine import GraphEngine
-from .master import DefaultMaster
+from .master import BaseMaster
 
 
 class Coordinator:
@@ -95,11 +95,12 @@ class Coordinator:
         self.start_graph_engine(self.config_parser.graph_config)
 
         # 3. Start Master
-        self.config_parser.master_config["sequence_order"] = (
-            self.graph_engine.sequence_order
-        )
+        self.config_parser.master_config["config"][
+            "sequence_order"
+        ] = self.graph_engine.sequence_order
         self.start_master(
-            self.config_parser.master_config,
+            self.config_parser.master_config["type"],
+            self.config_parser.master_config["config"],
             fixed_point_init=fixed_point_init,
             fixed_point_kwargs=fixed_point_kwargs,
         )
@@ -148,12 +149,17 @@ class Coordinator:
         )
 
     def start_master(
-        self, config: dict, fixed_point_init=False, fixed_point_kwargs=None
+        self,
+        master_type: str,
+        config: dict,
+        fixed_point_init=False,
+        fixed_point_kwargs=None,
     ):
         """
         Start the master algorithm with the given configuration.
 
         Args:
+            master_type (str): type of the master subclass to use.
             config (dict): configuration for the master algorithm containing the FMUs,
                 connections, sequence order, and loop method.
             fixed_point_init (bool): whether to use the fixed-point initialization method.
@@ -162,7 +168,10 @@ class Coordinator:
                 case the default values are used "solver": "fsolve",
                 "time_step": minimum_default_step_size, and "xtol": 1e-5.
         """
-        self.master = DefaultMaster(
+        # TODO: when all parameters of the master are standardized, we can directly pass
+        # the config dictionary in BaseMaster.create_master(type, config)
+        master_subclass = BaseMaster._masters_registry[master_type]
+        self.master = master_subclass(
             fmu_config_list=config["fmus"],
             connections=config["connections"],
             sequence_order=config["sequence_order"],

--- a/cofmupy/master/__init__.py
+++ b/cofmupy/master/__init__.py
@@ -23,6 +23,26 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-Module for Master algorithms.
+Module for Master algorithms. This module contains the base class for master algorithm
+and the child classes for different masters.
+
+The master algorithms are used to run the co-simulation and handle the algebraic loops.
+The base class `BaseMaster` defines the interface for the Master subclasses.
 """
+from .base_master import BaseMaster
 from .default_master import DefaultMaster
+
+# Register all the master subclasses. This is necessary to be able to create the master
+# from configuration.
+# If a new master subclass is added, it must be imported here and registered.
+list_of_masters = [
+    DefaultMaster,
+]
+
+for master in list_of_masters:
+    BaseMaster.register_master(master)
+
+__all__ = [
+    "BaseMaster",
+    "DefaultMaster",
+]

--- a/cofmupy/master/base_master.py
+++ b/cofmupy/master/base_master.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 IRT Saint Exupéry and HECATE European project - All rights reserved
+#
+# The 2-Clause BSD License
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+This module contains the base class for the master algorithms.
+"""
+from abc import abstractmethod
+from typing import Any
+
+
+class BaseMaster:
+    """
+    Base class for Master algorithm that runs the co-simulation and handles the
+    algebraic loops.
+
+    Child classes must implement the abstract methods defined in this class:
+        - variable_names: property returning the list of variable names in the system.
+        - get_variable: get the value of a variable.
+        - get_causality: get the causality of a variable (e.g., input, output).
+        - get_variable_type: get the type of a variable (e.g., Real, Integer).
+        - get_outputs: get the outputs at the current step.
+        - get_results: get the results of the simulation up to the current time.
+        - init_simulation: initialize the simulation environment.
+        - do_step: perform a simulation step.
+    """
+
+    # Type name of the master subclass (used in the configuration file)
+    type_name = None
+
+    # Registry of available master classes
+    _masters_registry = {}
+
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @classmethod
+    def register_master(cls, subclass):
+        """Register a subclass master in the registry.
+
+        The subclass must inherit from BaseMaster and have a `type_name` class
+        attribute. The `type_name` attribute is used to identify the master type in the
+        configuration file.
+
+        Args:
+            subclass (BaseMaster): master subclass to register.
+        """
+        if not issubclass(subclass, BaseMaster):
+            raise TypeError(f"Class {subclass.__name__} must inherit from BaseMaster.")
+        key = subclass.type_name
+        cls._masters_registry[key] = subclass
+
+    @classmethod
+    def create_master(cls, config_dict):
+        """Factory method to create a class instance based on config_dict.
+
+        The config_dict must contain a `type` key that corresponds to the `type_name`
+        class attribute of the master subclass. The config_dict also contains a config
+        dictionary that is passed to the master constructor.
+
+        Args:
+            config_dict (dict): configuration dictionary. Must contain a `type` key and
+                a `config` key to initialize the master.
+
+        Returns:
+            BaseMaster: a new master instance.
+        """
+        master_type = config_dict.get("type")
+        if master_type not in cls._masters_registry:
+            raise ValueError(
+                f"Unknown master type '{master_type}'."
+                f"Available types: {list(cls._masters_registry.keys())}"
+            )
+        return cls._masters_registry[master_type](**config_dict["config"])
+
+    @property
+    @abstractmethod
+    def variable_names(self) -> list[tuple[str, str]]:
+        """
+        Get the names of all variables in the system.
+
+        Returns:
+            list: list of variable names as (fmu_id, var_name) tuples.
+        """
+
+    @abstractmethod
+    def get_variable(self, name: tuple[str, str]):
+        """
+        Get the value of the given tuple fmu/variable.
+
+        Args:
+            name (tuple): variable name as (fmu_id, var_name).
+
+        Returns:
+            list: value of the variable, as a list.
+        """
+
+    @abstractmethod
+    def get_causality(self, name: tuple[str, str]) -> str:
+        """
+        Gets the causality of the given variable.
+
+        Args:
+            name (tuple): variable name as (fmu_id, var_name).
+
+        Returns:
+            str: causality of the variable.
+        """
+
+    @abstractmethod
+    def get_variable_type(self, name: tuple[str, str]) -> str:
+        """
+        Get the type of the given variable.
+
+        Args:
+            name (tuple): variable name as (fmu_id, var_name).
+
+        Returns:
+            str: type of the variable.
+        """
+
+    @abstractmethod
+    def get_outputs(self) -> dict[str, dict[str, Any]]:
+        """
+        Returns the output dictionary for the current step.
+
+        Returns:
+            dict: A dictionary containing the output values of the current step,
+                structured as `[FMU_ID][Var]`.
+        """
+
+    @abstractmethod
+    def get_results(self) -> dict:
+        """
+        Returns the results of the simulation, this includes the values of every output
+        variables, for each step, up until the current time of simulation.
+
+        Returns:
+            dict: A dictionnary containing output values of every step, structured as
+                [(FMU_ID, Var)]
+
+        """
+
+    @abstractmethod
+    def init_simulation(self, input_dict: dict[str, dict[str, Any]] = None):
+        """
+        Initializes the simulation environment, FMUs and variables.
+
+        Args:
+            input_dict (dict, optional): Dictionary of input values to set at
+                initialization. Defaults to None.
+        """
+
+    @abstractmethod
+    def do_step(self, step_size: float, input_dict=None, record_outputs=True) -> dict:
+        """
+        This method performs a single step of the system co-simulation. Input variables
+        are updated before simulation if an `input_dict` is given. Output variables are
+        retrieved after the step and returned as a dictionary. If `record_outputs` is
+        set to True, the output values are also stored in the global results dictionary.
+
+        Args:
+            step_size (float): The size of the simulation step.
+            input_dict (dict, optional): A dictionary containing input values for the
+                simulation. Defaults to None.
+            record_outputs (bool, optional): Whether to store the output values in the
+                results dictionary. Defaults to True.
+
+        Returns:
+            dict: A dictionary containing the output values for this step, structured as
+                `[FMU_ID][Var]`.
+        """

--- a/cofmupy/master/default_master.py
+++ b/cofmupy/master/default_master.py
@@ -33,16 +33,17 @@ This module provides a `DefaultMaster` class that handles FMU initialization, in
 setting, stepping, and result collection during simulation.
 
 """
+import copy
 from collections import defaultdict
 
 import numpy as np
 
 from ..utils import FixedPointInitializer
 from ..wrappers import FmuHandlerFactory
-import copy
+from .base_master import BaseMaster
 
 
-class DefaultMaster:
+class DefaultMaster(BaseMaster):
     """
     Manages and executes the co-simulation involving multiple FMUs.
 
@@ -97,6 +98,9 @@ class DefaultMaster:
     """
 
     # pylint: disable=too-many-instance-attributes
+
+    # Type name of the master (used in the configuration file and master registration)
+    type_name = "default"
 
     __keys = {
         "fmus": "FMUs",

--- a/tests/config_parser/test_config_parser.py
+++ b/tests/config_parser/test_config_parser.py
@@ -161,7 +161,7 @@ def test_build_master_config(algo_name):
         "cosim_method": algo_name
     }
     parser = ConfigParser(config_data)
-    assert "fmus" in parser.master_config["config"]
+    assert "fmu_config_list" in parser.master_config["config"]
     assert "connections" in parser.master_config["config"]
     assert len(parser.master_config["config"]["connections"]) == 1
     assert parser.master_config["config"]["cosim_method"] == algo_name

--- a/tests/config_parser/test_config_parser.py
+++ b/tests/config_parser/test_config_parser.py
@@ -161,10 +161,10 @@ def test_build_master_config(algo_name):
         "cosim_method": algo_name
     }
     parser = ConfigParser(config_data)
-    assert "fmus" in parser.master_config
-    assert "connections" in parser.master_config
-    assert len(parser.master_config["connections"]) == 1
-    assert parser.master_config["cosim_method"] == algo_name
+    assert "fmus" in parser.master_config["config"]
+    assert "connections" in parser.master_config["config"]
+    assert len(parser.master_config["config"]["connections"]) == 1
+    assert parser.master_config["config"]["cosim_method"] == algo_name
 
 
 def test_build_handlers_config():


### PR DESCRIPTION
This PR prepares the possibility to support other master algorithms:

- Introduce a `BaseMaster` abstract class with a common API for future master algorithms
- The `DefaultMaster` class is now derived from the `BaseMaster`
- The `Coordinator` is now agnostic to the `DefaultMaster` and creates an instance of Master using `BaseMaster`. Note that this is not yet perfect to support different master algorithms. The Master arguments must be grouped together in a single config dictionary.

The next step is to create a configuration for Master objects, like for stream handlers and storage: the JSON configuration file will gather the Master configuration items (e.g. `cosim_method`, `iterative`, `fixed_point_init`, etc.) in a specific section of the JSON file. The Master subclass will be instantiated based on these config items + the common arguments `fmus`, `connections`, `sequence_order`, etc.